### PR TITLE
fix: Prevent error if feature support is unknown for a client

### DIFF
--- a/src/doiuse.ts
+++ b/src/doiuse.ts
@@ -80,22 +80,22 @@ export class DoIUseEmail {
         const supportMap = getProperty(stats, emailClient);
 
         if (supportMap === void 0) {
-          throw new Error(`Feature \`${featureTitle}\` not found on \`${emailClient}\`.`);
-        }
+          this.warning(`\`${featureTitle}\` support is not known for \`${emailClient}\``);
+        } else {
+          const supportStatus = getEmailClientSupportStatus(supportMap);
+          if (supportStatus.type === 'none') {
+            this.error(`\`${featureTitle}\` is not supported by \`${emailClient}\``);
+          } else if (supportStatus.type === 'partial') {
+            this.warning(`\`${featureTitle}\` is only partially supported by \`${emailClient}\``);
+          }
 
-        const supportStatus = getEmailClientSupportStatus(supportMap);
-        if (supportStatus.type === 'none') {
-          this.error(`\`${featureTitle}\` is not supported by \`${emailClient}\``);
-        } else if (supportStatus.type === 'partial') {
-          this.warning(`\`${featureTitle}\` is only partially supported by \`${emailClient}\``);
-        }
-
-        for (const noteNumber of supportStatus.noteNumbers ?? []) {
-          this.note(
-            `Note about \`${featureTitle}\` support for \`${emailClient}\`: ${
-              feature.notes_by_num![String(noteNumber)]
-            }`
-          );
+          for (const noteNumber of supportStatus.noteNumbers ?? []) {
+            this.note(
+              `Note about \`${featureTitle}\` support for \`${emailClient}\`: ${
+                feature.notes_by_num![String(noteNumber)]
+              }`
+            );
+          }
         }
       }
     }

--- a/test/doiuse-email.test.ts
+++ b/test/doiuse-email.test.ts
@@ -72,6 +72,27 @@ describe('doIUseEmail() works', () => {
     expect(result).toMatchSnapshot();
   });
 
+  test('should warn on unknown support of inline-style features or a browser', () => {
+    // `table-layout` support is not known for `thunderbird.macos`
+    const code = outdent`
+			<!doctype html>
+			<html>
+				<body>
+					<div style='table-layout: auto'></div>
+				</body>
+			</html>
+		`;
+    const result = doIUseEmail(code, {
+      emailClients: ['thunderbird.macos']
+    });
+    expect(result.success).toEqual(true);
+    expect(result.warnings.length).toEqual(1);
+    expect(result.warnings[0]).toEqual(
+      '`table-layout` support is not known for `thunderbird.macos`'
+    );
+    expect(result).toMatchSnapshot();
+  });
+
   test('should work with selectors', () => {
     // Desktop webmail supports most selectors
     const code = outdent`


### PR DESCRIPTION
Thanks for this library! Users of smtp4dev love the feature that this enables.

In the source data, some features have unknown status for some clients. This must be because they've never been tested.

An example can be found here: https://www.caniemail.com/search/?s=table-layout
Node thunderbird.macosx which is shown in grey to denote this.

Currently, this library throws an error when hitting these.

This PR modifies this behaviour so these are returned as warnings.